### PR TITLE
also update babelrc: handles plugins, presets and their options

### DIFF
--- a/bin/babel-upgrade
+++ b/bin/babel-upgrade
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
-const { writePackageJSON } = require("../src");
+const path = require('path');
+const { writePackageJSON, writeBabelRC } = require("../src");
 const cwd = process.cwd();
 console.warn(`Current working directory: ${cwd}`);
 
+console.log("Updating ./.babelrc config");
+// TOOD: allow passing a specific path
+writeBabelRC(path.join(cwd, '.babelrc'));
+
 console.log("Updating closest package.json dependencies");
+// TOOD: allow passing a specific path
 writePackageJSON();
 // TODO: just do this automatically
 console.log("You'll need to re-run yarn or npm install");
-
-

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "golden-fleece": "^1.0.3",
+    "load-json-file": "^4.0.0",
     "read-pkg-up": "^3.0.0",
     "sort-keys": "^2.0.0",
     "write-pkg": "^3.1.0"

--- a/readme.md
+++ b/readme.md
@@ -8,13 +8,14 @@ npx babel-upgrade
 
 > Update dependencies, config file, files that require babel directly
 
-- [ ] Update `package.json`: `dependencies` and `devDependencies` to the "latest supported" version. 
+- [x] Update `package.json`: `dependencies` and `devDependencies` to the "latest supported" version. 
   - This includes doing all package renames
   - This includes upgrading the same package to the latest version
 - [ ] Update the babel config file(s).
-  - [ ] `.babelrc`
+  - [x] `.babelrc`
   - [ ] `.babelrc.js`
   - [ ] `package.json babel key`
+  - [ ] handle `env`
 - [ ] Update test files that use babel directly (`babel-types`, `babel-core`)
   - Update all requires/imports
   - Update the use of the Babel API (plugins, integrations)

--- a/src/__snapshots__/upgradeConfig.test.js.snap
+++ b/src/__snapshots__/upgradeConfig.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`packages 1`] = `
+Object {
+  "plugins": Array [
+    "@babel/plugin-transform-function-bind",
+    Array [
+      "@babel/plugin-transform-object-rest-spread",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    "@babel/plugin-transform-class-properties",
+  ],
+  "presets": Array [
+    "@babel/preset-es2015",
+    Array [
+      "@babel/preset-env",
+      Object {
+        "modules": false,
+      },
+    ],
+    "@babel/preset-react",
+  ],
+}
+`;

--- a/src/babelrc.json
+++ b/src/babelrc.json
@@ -1,0 +1,12 @@
+{
+  "presets": [
+    "es2015",
+    ["env", { "modules": false }],
+    "react"
+  ],
+  "plugins": [
+    "transform-function-bind",
+    ["transform-object-rest-spread", { "useBuiltIns": true }],
+    "transform-class-properties"
+  ]
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 const path = require('path');
 const readPkgUp = require('read-pkg-up');
 const sortKeys = require('sort-keys');
+const loadJsonFile = require('load-json-file');
 const writeJsonFile = require('write-json-file');
 
 const upgradeDeps = require('./upgradeDeps');
+const upgradeConfig = require('./upgradeConfig');
 
 function getLatestVersion() {
   return "7.0.0-beta.39";
@@ -31,8 +33,27 @@ async function writePackageJSON() {
   await writeJsonFile(path, pkg, { detectIndent: true });
 }
 
+function updateBabelRC(config) {
+  return upgradeConfig(config);
+}
+
+async function writeBabelRC(configPath) {
+  let json;
+
+  try {
+    json = await loadJsonFile(configPath);
+  } catch (e) {
+    throw new Error(`babel-upgrade: ${configPath} does not contain a .babelrc file`);
+  }
+
+  json = updateBabelRC(json);
+
+  await writeJsonFile(configPath, json, { detectIndent: true });
+}
+
 module.exports = {
   updatePackageJSON,
   writePackageJSON,
+  writeBabelRC,
   getLatestVersion
 };

--- a/src/packageData.js
+++ b/src/packageData.js
@@ -227,19 +227,21 @@ const misc = {
   // 'babylon': '@babel/parser',
 }
 
-const oldPackages = Object.assign(
+const plugins = Object.assign({}, transformPlugins, syntaxPlugins, proposalPlugins);
+
+const packages = Object.assign(
   {},
-  transformPlugins,
-  syntaxPlugins,
-  proposalPlugins,
+  plugins,
   presets,
   helpers,
   misc,
 );
 
-const latestPackages = Array.from(new Set(Object.values(oldPackages)));
+const latestPackages = Array.from(new Set(Object.values(packages)));
 
 module.exports = {
-  oldPackages,
+  packages,
+  presets,
+  plugins,
   latestPackages,
 };

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -1,0 +1,53 @@
+const { presets: oldPresets, plugins: oldPlugins } = require('./packageData');
+
+module.exports = function upgradeConfig(config) {
+  config = Object.assign({}, config);
+
+  const presets = config.presets;
+
+  // check if presets are there
+  if (presets) {
+    // assume it's an array
+    for (let i = 0; i < presets.length; i++) {
+      let preset = presets[i];
+      const presetsToReplace = Object.keys(oldPresets).map(p => p.replace('babel-preset-', ''));
+
+      // check if it's a preset with options (an array)
+      if (Array.isArray(preset)) {
+        if (presetsToReplace.includes(preset[0])) {
+          preset[0] = `@babel/preset-${preset[0]}`;
+        }
+      } else {
+        // should be a string now
+        if (presetsToReplace.includes(preset)) {
+          presets.splice(i, 1, `@babel/preset-${preset}`)
+        }
+      }
+    }
+  }
+
+  const plugins = config.plugins;
+
+  // check if plugins are there
+  if (plugins) {
+    // assume it's an array
+    for (let i = 0; i < plugins.length; i++) {
+      let plugin = plugins[i];
+      const pluginsToReplace = Object.keys(oldPlugins).map(p => p.replace('babel-plugin-', ''));
+
+      // check if it's a plugin with options (an array)
+      if (Array.isArray(plugin)) {
+        if (pluginsToReplace.includes(plugin[0])) {
+          plugin[0] = `@babel/plugin-${plugin[0]}`;
+        }
+      } else {
+        // should be a string now
+        if (pluginsToReplace.includes(plugin)) {
+          plugins.splice(i, 1, `@babel/plugin-${plugin}`)
+        }
+      }
+    }
+  }
+
+  return config;
+};

--- a/src/upgradeConfig.test.js
+++ b/src/upgradeConfig.test.js
@@ -1,0 +1,6 @@
+const upgradeConfig = require('./upgradeConfig');
+const babelrcFixture = require('./babelrc');
+
+test('packages', () => {
+  expect(upgradeConfig(babelrcFixture)).toMatchSnapshot();
+});

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -1,4 +1,4 @@
-const { oldPackages, latestPackages } = require('./packageData');
+const { packages: oldPackages, latestPackages } = require('./packageData');
 
 function upgradeDeps(dependencies, version) {
   for (let pkg of Object.keys(dependencies)) {


### PR DESCRIPTION
For a `.babelrc`

- handle presets + options
- handle plugins + options

- [ ] next steps: make it work on `"env"` key, and `package.json` since same logic