### PR TITLE
Confirm package.json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,12 @@ function upgradeScripts(scripts) {
 
 function updatePackageJSON(pkg) {
   console.log("Updating closest package.json dependencies");
+
+  if (!pkg) {
+    console.log("package.json not found");
+    process.exit(1);
+  }
+
   if (pkg.devDependencies) {
     pkg.devDependencies = sortKeys(upgradeDeps(
       pkg.devDependencies,


### PR DESCRIPTION
Currently, the following error occurs when we don't have package.json.

```
Current working directory: /Users/yuta_hiroto/Desktop/test
You'll need to re-run yarn or npm install
Updating closest package.json dependencies
(node:97666) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'devDependencies' of undefined
    at updatePackageJSON (/Users/yuta_hiroto/Programming/babel-upgrade/src/index.js:27:11)
    at writePackageJSON (/Users/yuta_hiroto/Programming/babel-upgrade/src/index.js:51:9)
    at <anonymous>
(node:97666) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:97666) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```