### PR TITLE
Check Node's version

### DIFF
--- a/bin/babel-upgrade
+++ b/bin/babel-upgrade
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 
 const path = require('path');
-const { writePackageJSON, writeBabelRC } = require("../src");
+const { isAcceptedNodeVersion, writePackageJSON, writeBabelRC } = require("../src");
 const cwd = process.cwd();
-console.warn(`Current working directory: ${cwd}`);
+
+if (!isAcceptedNodeVersion()) {
+  throw new Error("Babel 7 will only support Node 4 and higher");
+}
 
 // TOOD: allow passing a specific path
 writeBabelRC(path.join(cwd, '.babelrc'));

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ npx babel-upgrade
   - This includes upgrading the same package to the latest version
   - [x] add `@babel/core` peerDep
   - [x] modify scripts for mocha + `@babel/register`
-  - [ ] throw/warn if engines is < node 4 or current node is < 4?
+  - [x] throw/warn if engines is < node 4 or current node is < 4?
   - [ ] log when replacing out preset-es2015,16,17,latest as FYI
   - [ ] if `babel-node` is used, import `@babel/node`?
 - [ ] Update the babel config file(s).

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,14 @@ const fs = require('fs');
 const pify = require('pify');
 const JSON5 = require('json5');
 const writeJsonFile = require('write-json-file');
+const semver = require('semver');
 
 const upgradeDeps = require('./upgradeDeps');
 const upgradeConfig = require('./upgradeConfig');
+
+function isAcceptedNodeVersion() {
+  return semver.satisfies(process.version, '>= 4');
+}
 
 function getLatestVersion() {
   return "7.0.0-beta.39";
@@ -82,6 +87,7 @@ async function writeBabelRC(configPath) {
 }
 
 module.exports = {
+  isAcceptedNodeVersion,
   updatePackageJSON,
   writePackageJSON,
   readBabelRC,


### PR DESCRIPTION
Make sure the Node's version is less than 4.

> throw/warn if engines is < node 4 or current node is < 4?

@hzoo How do we do in case of error? 
And this code does not work with 4 or less because we use async/await 😭 
So, we only need to check package.json's engine?