### PR TITLE
run over src on node 8

### DIFF
--- a/bin/babel-upgrade
+++ b/bin/babel-upgrade
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
-console.log("🙌 Thanks for trying out https://github.com/babel/babel-upgrade!");
+console.log("🙌  Thanks for trying out https://github.com/babel/babel-upgrade!");
 console.log("");
+
 require('@babel/polyfill');
-require('../lib/bin');
+
+parseInt(process.versions.node, 10) < 8
+  ? require('../lib/bin')
+  : require('../src/bin');

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "lib",
+    "src",
     "bin",
     "readme.md"
   ],

--- a/src/bin.js
+++ b/src/bin.js
@@ -18,6 +18,7 @@ if (!isAcceptedNodeVersion()) {
   if (packages.length === 1) {
     if (paths.length > 1) {
       console.log("We suggest using the new 'overrides' option instead of nested .babelrc's, can check out http://new.babeljs.io/docs/en/next/babelrc.html#overrides");
+      console.log("");
     }
     paths.forEach(p => writeBabelRC(p));
   }


### PR DESCRIPTION
I guess you could even just run `@babel/register` and target the current node version?