### PR TITLE
Auto run npm/yarn after updating dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,12 +1785,13 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.4.tgz",
+      "integrity": "sha512-LDYnK41m8td+nBTk5Jmn55aGVP18iYuUqoM1X3u+ptt7M/g9FPS8C38PNoJTMfjoNx4fmiwWToPpiZklGRLbIA==",
       "requires": {
-        "lru-cache": "4.1.1",
+        "nice-try": "1.0.4",
+        "path-key": "2.0.1",
+        "semver": "5.5.0",
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
@@ -2058,6 +2059,19 @@
         "p-finally": "1.0.0",
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        }
       }
     },
     "exit": {
@@ -3498,6 +3512,11 @@
         }
       }
     },
+    "has-yarn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
+      "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac="
+    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -3839,8 +3858,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -5122,6 +5140,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5464,8 +5487,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.5",
@@ -5992,7 +6014,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -6000,8 +6021,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -7083,7 +7103,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   "license": "MIT",
   "dependencies": {
     "@babel/polyfill": "7.0.0-beta.40",
+    "cross-spawn": "^6.0.4",
     "globby": "^8.0.1",
+    "has-yarn": "^1.0.0",
     "json5": "^0.5.1",
     "pify": "^3.0.0",
     "read-pkg-up": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ npx babel-upgrade
 ```
 - [x] Modify `mocha.opts`
 - [ ] Log when replacing out preset-es2015,16,17,latest as FYI
-- [ ] Auto run npm/yarn after updating dependencies
+- [x] Auto run npm/yarn after updating dependencies
 - [ ] figure out how to change nested .babelrcs into using "overrides" instead
 - [ ] monorepo support
 - [ ] `.babelrc.js` and other js files with a config like presets, `webpack.config.js`

--- a/src/bin.js
+++ b/src/bin.js
@@ -1,5 +1,4 @@
-const path = require('path');
-const { isAcceptedNodeVersion, writePackageJSON, writeBabelRC, writeMochaOpts } = require('.');
+const { isAcceptedNodeVersion, writePackageJSON, writeBabelRC, writeMochaOpts, installDeps } = require('.');
 const globby = require('globby');
 const cwd = process.cwd();
 
@@ -24,9 +23,8 @@ if (!isAcceptedNodeVersion()) {
   }
 
   mochaOpts.forEach(p => writeMochaOpts(p));
-})();
 
-// TOOD: allow passing a specific path
-writePackageJSON();
-// TODO: just do this automatically
-console.log("You'll need to re-run yarn or npm install");
+  // TOOD: allow passing a specific path
+  await writePackageJSON();
+  installDeps(cwd);
+})();

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const writeFile = require('write');
 
 const upgradeDeps = require('./upgradeDeps');
 const upgradeConfig = require('./upgradeConfig');
+const installDeps = require('./installDeps');
 
 function isAcceptedNodeVersion() {
   return semver.satisfies(process.version, '>= 4');
@@ -137,5 +138,6 @@ module.exports = {
   readBabelRC,
   writeBabelRC,
   getLatestVersion,
-  writeMochaOpts
+  writeMochaOpts,
+  installDeps
 };

--- a/src/installDeps.js
+++ b/src/installDeps.js
@@ -1,0 +1,12 @@
+const hasYarn = require('has-yarn');
+const spawn = require('cross-spawn');
+
+module.exports = function installDeps(cwd) {
+  const isYarn = hasYarn(cwd);
+  const cmd = isYarn ? 'yarn' : 'npm';
+  const args = ['install'];
+
+  console.log(`Installing dependencies using "${cmd}"`);
+
+  spawn.sync(cmd, args, { stdio: 'inherit' });
+};


### PR DESCRIPTION
Hi folks, this is an implementation of auto run yarn/npm after updating dependencies. 

Details:
- Added yarn check
- Run `yarn install` if yarn is available otherwise run `npm install`
- Removed unused `path` import in bin.js