### PR TITLE
Update packages appropriately for Webpack v1 compatibility

### DIFF
--- a/__tests__/__snapshots__/packageData.test.js.snap
+++ b/__tests__/__snapshots__/packageData.test.js.snap
@@ -245,3 +245,17 @@ Object {
   "rollup-plugin-babel": "^4.0.0-beta.2",
 }
 `;
+
+exports[`webpack v1 compatibility 1`] = `
+Object {
+  "devDependencies": Object {
+    "@babel/core": "7.0.0-beta.39",
+    "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.39",
+    "@babel/preset-env": "7.0.0-beta.39",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-loader": "7.1.1",
+    "webpack": "^1.15.0",
+  },
+  "name": "webpack-v1-compatibility",
+}
+`;

--- a/__tests__/packageData.test.js
+++ b/__tests__/packageData.test.js
@@ -3,6 +3,7 @@ const upgradeDeps = require('../src/upgradeDeps');
 const babelCoreFixture = require('../fixtures/babel-core');
 const jestFixture = require('../fixtures/jest');
 const depsFixture = require('../fixtures/deps');
+const webpackV1Fixture = require('../fixtures/webpack-v1');
 const depsFixtureEarlierBeta = require('../fixtures/deps-earlier-beta.json');
 const scriptsMochaFixture = require('../fixtures/scripts-mocha');
 const scriptsBabelNodeFixture = require('../fixtures/scripts-babel-node');
@@ -68,4 +69,8 @@ test('@babel/core peerDep', async () => {
 
 test('jest babel-core bridge', async () => {
   expect(await updatePackageJSON(jestFixture)).toMatchSnapshot();
+});
+
+test('webpack v1 compatibility', async () => {
+  expect(await updatePackageJSON(webpackV1Fixture)).toMatchSnapshot();
 });

--- a/fixtures/webpack-v1.json
+++ b/fixtures/webpack-v1.json
@@ -1,0 +1,9 @@
+{
+  "name": "webpack-v1-compatibility",
+  "devDependencies": {
+    "babel-loader": "^7.1.2",
+    "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-preset-es2015": "^6.18.0",
+    "webpack": "^1.15.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -64,20 +64,11 @@ async function updatePackageJSON(pkg) {
   };
 
   if (pkg.devDependencies) {
-    pkg.devDependencies = upgradeDeps(
+    pkg.devDependencies = sortKeys(upgradeDeps(
       pkg.devDependencies,
       getLatestVersion(),
       upgradeDepOptions,
-    );
-
-    const devDeps = Object.keys(pkg.devDependencies);
-    // use babel-bridge for jest
-    // maybe should do this for other tools?
-    if (devDeps.includes("jest") && !devDeps.includes("babel-core")) {
-      pkg.devDependencies["babel-core"] = "^7.0.0-bridge.0";
-    }
-
-    pkg.devDependencies = sortKeys(pkg.devDependencies);
+    ));
   }
 
   if (pkg.dependencies) {


### PR DESCRIPTION
Fixes #17.

When `babel-upgrade` is run over a project that uses Webpack v1:

- Use `babel-loader@7.1.1` (from [this suggestion](https://github.com/babel/babel-loader/issues/505#issuecomment-324268931))
- Use `babel-core@^7.0.0-bridge.0`

[This repo](https://github.com/adityavohra7/babel-upgrade-issue-17) repros the bug from [this issue](https://github.com/babel/babel-upgrade/issues/17). Running `babel-upgrade --install` _with the diff_ from this PR fixes the Webpack error.