### PR TITLE
Monorepo support

### DIFF
--- a/__tests__/packageData.test.js
+++ b/__tests__/packageData.test.js
@@ -59,18 +59,18 @@ describe('upgradeDeps', () => {
 });
 
 test('scripts', async () => {
-  expect(await updatePackageJSON(scriptsMochaFixture)).toMatchSnapshot();
-  expect(await updatePackageJSON(scriptsBabelNodeFixture)).toMatchSnapshot();
+  expect(await updatePackageJSON(scriptsMochaFixture, __dirname)).toMatchSnapshot();
+  expect(await updatePackageJSON(scriptsBabelNodeFixture, __dirname)).toMatchSnapshot();
 });
 
 test('@babel/core peerDep', async () => {
-  expect(await updatePackageJSON(babelCoreFixture)).toMatchSnapshot();
+  expect(await updatePackageJSON(babelCoreFixture, __dirname)).toMatchSnapshot();
 });
 
 test('jest babel-core bridge', async () => {
-  expect(await updatePackageJSON(jestFixture)).toMatchSnapshot();
+  expect(await updatePackageJSON(jestFixture, __dirname)).toMatchSnapshot();
 });
 
 test('webpack v1 compatibility', async () => {
-  expect(await updatePackageJSON(webpackV1Fixture)).toMatchSnapshot();
+  expect(await updatePackageJSON(webpackV1Fixture, __dirname)).toMatchSnapshot();
 });

--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,7 @@ npx babel-upgrade --install
 
 - [ ] Log when replacing out preset-es2015,16,17,latest as FYI
 - [ ] Figure out how to change nested .babelrcs into using "overrides" instead
-- [ ] Monorepo support
+- [x] Monorepo support
 - [ ] `.babelrc.js` and other js files with a config like presets, `webpack.config.js`
 - [ ] convert `only`/`ignore` if necessary
 - [ ] remove `typeof-symbol` if using `@babel/preset-env` + loose

--- a/src/bin.js
+++ b/src/bin.js
@@ -29,13 +29,11 @@ async function hasFlow() {
       console.log("We suggest using the new 'overrides' option instead of nested .babelrc's, can check out http://new.babeljs.io/docs/en/next/babelrc.html#overrides");
       console.log("");
     }
-    paths.forEach(p => writeBabelRC(p, upgradeOptions));
   }
 
+  paths.forEach(p => writeBabelRC(p, upgradeOptions));
   mochaOpts.forEach(p => writeMochaOpts(p, upgradeOptions));
-
-  // TODO: allow passing a specific path
-  await writePackageJSON(upgradeOptions);
+  await Promise.all(packages.map(p => writePackageJSON(p, upgradeOptions)));
 
   // TODO: add smarter CLI option handling if we support more options
   if (process.argv[2] === '--install') {

--- a/src/index.js
+++ b/src/index.js
@@ -36,9 +36,9 @@ function upgradeScripts(scripts) {
   return scripts;
 }
 
-async function updatePackageJSON(pkg, options) {
+async function updatePackageJSON(pkg, pkgPath, options) {
   if (process.env.NODE_ENV !== 'test') {
-    console.log("Updating closest package.json dependencies");
+    console.log(`Updating package.json dependencies at ${pkgPath}`);
   }
 
   if (!pkg) {
@@ -76,17 +76,17 @@ async function updatePackageJSON(pkg, options) {
   return pkg;
 }
 
-async function writePackageJSON(options) {
-  let { pkg, path } = await readPkgUp({ normalize: false });
+async function writePackageJSON(pkgPath, options) {
+  let { pkg, path: filePath } = await readPkgUp({ normalize: false, cwd: pkgPath ? path.dirname(pkgPath) : undefined });
 
-  pkg = await updatePackageJSON(pkg, options);
+  pkg = await updatePackageJSON(pkg, pkgPath, options);
 
   if (pkg.babel) {
     console.log("Updating package.json 'babel' config");
     pkg.babel = upgradeConfig(pkg.babel, options);
   }
 
-  await writeJsonFile(path, pkg, { detectIndent: true });
+  await writeJsonFile(filePath, pkg, { detectIndent: true });
 }
 
 async function installDeps() {

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ async function writePackageJSON(pkgPath, options) {
   pkg = await updatePackageJSON(pkg, pkgPath, options);
 
   if (pkg.babel) {
-    console.log("Updating package.json 'babel' config");
+    console.log(`Updating package.json 'babel' config at ${pkgPath}`);
     pkg.babel = upgradeConfig(pkg.babel, options);
   }
 


### PR DESCRIPTION
Find all existings of .babelrc and package.json not in node_modules
and update them.
Parameterize writePackageJSON with a relative package.json path
from globby.
Improve log output for babel config
Look for .flowconfig in each package.json directory only

I think this needs some more testing with different projects. I ran it on babel and react, which also gave me a hint to adjust the .flowconfig lookup which I am not happy with yet. But I have no time today to invest further and I also do not have experience with flow, so maybe someone else can try it out.