### PR TITLE
Add @babel/core for custom presets and plugins that are not replaced by babel-upgrade

### DIFF
--- a/__tests__/__snapshots__/packageData.test.js.snap
+++ b/__tests__/__snapshots__/packageData.test.js.snap
@@ -42,7 +42,6 @@ exports[`scripts 2`] = `
 Object {
   "devDependencies": Object {
     "@babel/cli": "7.0.0-beta.40",
-    "@babel/core": "7.0.0-beta.40",
     "@babel/node": "7.0.0-beta.40",
   },
   "name": "scripts-babel-node",

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -46,7 +46,10 @@ module.exports = function upgradeDeps(dependencies, version, options = {}) {
   if (
     !dependencies['@babel/core'] &&
     Object.keys(dependencies).some(a =>
-      a.startsWith('@babel/plugin') || a.startsWith('@babel/preset') || a === '@babel/cli')
+      a.startsWith('@babel/plugin') ||
+      a.startsWith('@babel/preset') ||
+      a.startsWith('babel-plugin') ||
+      a.startsWith('babel-preset'))
   ) {
     dependencies['@babel/core'] = version;
   }


### PR DESCRIPTION
Custom presets/plugins will not be updated by `babel-upgrade`. Afaik, these will also require `@babel/core`? This is probs a better alternative to [this PR](https://github.com/babel/babel-upgrade/pull/44#issuecomment-369403762). Let me know what you think!