### PR TITLE
handling for spec/loose default changes for template literals and class properties

### DIFF
--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -13,7 +13,12 @@ Object {
   },
   "plugins": Array [
     "@babel/plugin-proposal-function-bind",
-    "@babel/plugin-proposal-class-properties",
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
   ],
   "presets": Array [
     "@babel/preset-env",
@@ -57,7 +62,12 @@ Object {
         "useBuiltIns": true,
       },
     ],
-    "@babel/plugin-proposal-class-properties",
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
   ],
   "presets": Array [
     "@babel/preset-env",
@@ -97,7 +107,12 @@ Object {
         "useBuiltIns": true,
       },
     ],
-    "@babel/plugin-proposal-class-properties",
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
   ],
   "presets": Array [
     "@babel/preset-env",
@@ -123,6 +138,89 @@ Object {
   },
   "plugins": Array [
     "lodash",
+  ],
+}
+`;
+
+exports[`sets \`loose\` option on plugins that are now spec by default if needed 1`] = `
+Object {
+  "plugins": Array [
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-transform-template-literals",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-transform-template-literals",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-transform-template-literals",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-transform-template-literals",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-transform-template-literals",
+      Object {
+        "loose": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-transform-template-literals",
+      Object {
+        "loose": true,
+      },
+    ],
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-transform-template-literals",
+    "@babel/plugin-transform-template-literals",
   ],
 }
 `;

--- a/__tests__/upgradeConfig.test.js
+++ b/__tests__/upgradeConfig.test.js
@@ -35,6 +35,29 @@ test('rename community packages', () => {
   })).toMatchSnapshot();
 });
 
+test('sets `loose` option on plugins that are now spec by default if needed', () => {
+  expect(upgradeConfig({
+    plugins: [
+      'babel-plugin-transform-class-properties',
+      '@babel/plugin-transform-class-properties',
+      'babel-plugin-transform-es2015-template-literals',
+      '@babel/plugin-transform-es2015-template-literals',
+      ['babel-plugin-transform-class-properties'],
+      ['@babel/plugin-transform-class-properties'],
+      ['babel-plugin-transform-es2015-template-literals'],
+      ['@babel/plugin-transform-es2015-template-literals'],
+      ['babel-plugin-transform-class-properties', { spec: false }],
+      ['@babel/plugin-transform-class-properties', { spec: false }],
+      ['babel-plugin-transform-es2015-template-literals', { spec: false }],
+      ['@babel/plugin-transform-es2015-template-literals', { spec: false }],
+      ['babel-plugin-transform-class-properties', { spec: true }],
+      ['@babel/plugin-transform-class-properties', { spec: true }],
+      ['babel-plugin-transform-es2015-template-literals', { spec: true }],
+      ['@babel/plugin-transform-es2015-template-literals', { spec: true }]
+    ]
+  })).toMatchSnapshot();
+});
+
 test('packages (json5)', async () => {
   const json5Data = await readBabelRC(JSON5_PATH);
   expect(upgradeConfig(json5Data)).toMatchSnapshot();

--- a/src/packageData.js
+++ b/src/packageData.js
@@ -245,9 +245,15 @@ const packages = Object.assign(
 
 const latestPackages = new Set(Object.values(packages));
 
+const pluginsNowSpecByDefault = new Set([
+  '@babel/plugin-transform-template-literals',
+  '@babel/plugin-proposal-class-properties'
+]);
+
 module.exports = {
   packages,
   presets,
   plugins,
   latestPackages,
+  pluginsNowSpecByDefault
 };


### PR DESCRIPTION
as discussed in https://github.com/babel/babel-upgrade/issues/10

currently, this logs to the console in any instance where these plugins were not explicitly included in config

only handles `spec` for old template literals transform -- should it do anything with the old `loose` flag as well?

after working in this file a bit, i've got some ideas for refactors, but i'll do that in a separate PR if i find the time

