### PR TITLE
fix bug breaking non-array presets with `@babel/` prefix

### DIFF
--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -48,6 +48,16 @@ Object {
 }
 `;
 
+exports[`handles @babel prefix in plugins 1`] = `
+Object {
+  "plugins": Array [
+    "@babel/plugin-proposal-async-generator-functions",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-decorators",
+  ],
+}
+`;
+
 exports[`package that is removed 1`] = `
 Object {
   "plugins": Array [

--- a/__tests__/upgradeConfig.test.js
+++ b/__tests__/upgradeConfig.test.js
@@ -71,3 +71,14 @@ test('does not another flow preset if already present and hasFlow option passed'
   expect(upgradeConfig(config, { hasFlow: true })).toMatchSnapshot();
 });
 
+test('handles @babel prefix in plugins', () => {
+  const config = {
+    "plugins": [
+      '@babel/plugin-transform-async-generator-functions',
+      '@babel/plugin-transform-class-properties',
+      '@babel/plugin-transform-decorators'
+    ],
+  };
+
+  expect(upgradeConfig(config)).toMatchSnapshot();
+});

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -79,7 +79,7 @@ function changePlugins(config) {
           }
         }
       } else {
-        if (plugin.indexOf('babel-plugin') !== 0 && plugin[0].indexOf('@babel/') !== 0) {
+        if (plugin.indexOf('babel-plugin') !== 0 && plugin.indexOf('@babel/') !== 0) {
           plugin = `babel-plugin-${plugin}`;
         }
         if (pluginsToReplace.includes(plugin)) {


### PR DESCRIPTION
plugins with `@babel/` were not being recognized, resulted in them not being properly replaced