### PR TITLE
Upgrade packages in Ava's setting file

### DIFF
--- a/__tests__/__snapshots__/packageData.test.js.snap
+++ b/__tests__/__snapshots__/packageData.test.js.snap
@@ -260,11 +260,35 @@ Object {
         "plugins": Array [
           "@babel/plugin-syntax-jsx",
           "@babel/plugin-proposal-object-rest-spread",
+          "@babel/plugin-syntax-dynamic-import",
+          "@babel/plugin-syntax-import-meta",
+          "@babel/plugin-proposal-class-properties",
+          "@babel/plugin-proposal-json-strings",
+          Array [
+            "@babel/plugin-proposal-decorators",
+            Object {
+              "legacy": true,
+            },
+          ],
+          "@babel/plugin-proposal-function-sent",
+          "@babel/plugin-proposal-export-namespace-from",
+          "@babel/plugin-proposal-numeric-separator",
+          "@babel/plugin-proposal-throw-expressions",
+          "@babel/plugin-proposal-export-default-from",
+          "@babel/plugin-proposal-logical-assignment-operators",
+          "@babel/plugin-proposal-optional-chaining",
+          Array [
+            "@babel/plugin-proposal-pipeline-operator",
+            Object {
+              "proposal": "minimal",
+            },
+          ],
+          "@babel/plugin-proposal-nullish-coalescing-operator",
+          "@babel/plugin-proposal-do-expressions",
+          "@babel/plugin-proposal-function-bind",
         ],
         "presets": Array [
-          "@babel/preset-stage-3",
           "@babel/preset-env",
-          "@babel/preset-stage-0",
           "@babel/preset-react",
           "@ava/transform-test-files",
           Array [

--- a/__tests__/__snapshots__/packageData.test.js.snap
+++ b/__tests__/__snapshots__/packageData.test.js.snap
@@ -247,6 +247,38 @@ Object {
 }
 `;
 
+exports[`upgrades packages in ava 1`] = `
+Object {
+  "ava": Object {
+    "babel": Object {
+      "testOptions": Object {
+        "babelrc": false,
+        "plugins": Array [
+          "@babel/plugin-syntax-jsx",
+          "@babel/plugin-proposal-object-rest-spread",
+        ],
+        "presets": Array [
+          "@babel/preset-stage-3",
+          "@babel/preset-env",
+          "@babel/preset-stage-0",
+          "@babel/preset-react",
+          "@ava/transform-test-files",
+          Array [
+            "module:ava/stage-4",
+            false,
+          ],
+        ],
+      },
+    },
+    "require": Array [
+      "@babel/polyfill",
+      "@babel/register",
+    ],
+  },
+  "name": "upgrade-packages-in-ava",
+}
+`;
+
 exports[`webpack v1 compatibility 1`] = `
 Object {
   "devDependencies": Object {

--- a/__tests__/packageData.test.js
+++ b/__tests__/packageData.test.js
@@ -1,6 +1,7 @@
 const { updatePackageJSON } = require('../src/');
 const upgradeDeps = require('../src/upgradeDeps');
 const babelCoreFixture = require('../fixtures/babel-core');
+const avaFixture = require('../fixtures/ava');
 const jestFixture = require('../fixtures/jest');
 const depsFixture = require('../fixtures/deps');
 const webpackV1Fixture = require('../fixtures/webpack-v1');
@@ -74,3 +75,7 @@ test('jest babel-core bridge', async () => {
 test('webpack v1 compatibility', async () => {
   expect(await updatePackageJSON(webpackV1Fixture)).toMatchSnapshot();
 });
+
+test('upgrades packages in ava', async () => {
+  expect(await updatePackageJSON(avaFixture)).toMatchSnapshot();
+})

--- a/fixtures/ava.json
+++ b/fixtures/ava.json
@@ -1,0 +1,26 @@
+{
+  "name": "upgrade-packages-in-ava",
+  "ava": {
+    "require": [
+      "@babel/polyfill",
+      "babel-register"
+    ],
+    "babel": {
+      "testOptions": {
+        "babelrc": false,
+        "plugins": [
+          "@babel/plugin-syntax-jsx",
+          "transform-object-rest-spread"
+        ],
+        "presets": [
+          "@babel/preset-stage-3",
+          "es2015",
+          "stage-0",
+          "react",
+          "@ava/transform-test-files",
+          ["module:ava/stage-4", false]
+        ]
+      }
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const writeFile = require('write');
 const crossSpawn = require('cross-spawn');
 const hasYarn = require('has-yarn');
 
+const { packages } = require('./packageData');
 const upgradeDeps = require('./upgradeDeps');
 const upgradeConfig = require('./upgradeConfig');
 
@@ -71,6 +72,17 @@ async function updatePackageJSON(pkg, options) {
       getLatestVersion(),
       options,
     ));
+  }
+
+  // ava
+  if (pkg.ava) {
+    if (pkg.ava.require && Array.isArray(pkg.ava.require)) {
+      pkg.ava.require = pkg.ava.require.map((p) => packages[p] || p);
+    }
+
+    if (pkg.ava.babel && pkg.ava.babel.testOptions) {
+      pkg.ava.babel.testOptions = upgradeConfig(pkg.ava.babel.testOptions, options);
+    }
   }
 
   return pkg;

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -17,7 +17,11 @@ function changePresets(config, options = {}) {
 
       // check if it's a preset with options (an array)
       if (Array.isArray(preset)) {
-        if (preset[0].indexOf('babel-preset') !== 0 && preset[0].indexOf('@babel/') !== 0) {
+        if (
+          !preset[0].includes('babel-preset') &&
+          !preset[0].includes('@babel/') &&
+          !preset[0].includes('module:ava')
+        ) {
           preset[0] = `babel-preset-${preset[0]}`;
         }
         if (presetsToReplace.includes(preset[0])) {
@@ -29,7 +33,11 @@ function changePresets(config, options = {}) {
           }
         }
       } else {
-        if (preset.indexOf('babel-preset') !== 0 && preset.indexOf('@babel/') !== 0) {
+        if (
+          !preset.includes('babel-preset') &&
+          !preset.includes('@babel/') &&
+          !preset[0].includes('module:ava')
+        ) {
           preset = `babel-preset-${preset}`;
         }
         if (presetsToReplace.includes(preset)) {
@@ -66,7 +74,7 @@ function changePlugins(config) {
       // check if it's a plugin with options (an array)
       if (Array.isArray(plugin)) {
 
-        if (plugin[0].indexOf('babel-plugin') !== 0 && plugin[0].indexOf('@babel/') !== 0) {
+        if (!plugin[0].includes('babel-plugin') && !plugin[0].includes('@babel/')) {
           plugin[0] = `babel-plugin-${plugin[0]}`;
         }
 
@@ -79,7 +87,7 @@ function changePlugins(config) {
           }
         }
       } else {
-        if (plugin.indexOf('babel-plugin') !== 0 && plugin.indexOf('@babel/') !== 0) {
+        if (!plugin.includes('babel-plugin') && !plugin.includes('@babel/')) {
           plugin = `babel-plugin-${plugin}`;
         }
         if (pluginsToReplace.includes(plugin)) {


### PR DESCRIPTION
Update packages of ava configuration written in package.json.

I think that upgrade feature is useful because Ava is waiting for Babel7.
https://github.com/avajs/ava/releases/tag/v1.0.0-beta.3

docs:
- babel6: https://github.com/avajs/ava/tree/v0.25.0#es2017-support
- babel7: https://github.com/avajs/ava/blob/master/docs/recipes/babel.md