### PR TITLE
refactor package data accessing, set up for per-package options transformer functions

### DIFF
--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -48,6 +48,17 @@ Object {
 }
 `;
 
+exports[`does not another flow preset if already present in an array and hasFlow option passed 1`] = `
+Object {
+  "presets": Array [
+    "@babel/preset-react",
+    Array [
+      "@babel/preset-flow",
+    ],
+  ],
+}
+`;
+
 exports[`package that is removed 1`] = `
 Object {
   "plugins": Array [

--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -31,15 +31,7 @@ Object {
 }
 `;
 
-exports[`does not add flow preset if hasFlow option is not passed 1`] = `
-Object {
-  "presets": Array [
-    "@babel/preset-react",
-  ],
-}
-`;
-
-exports[`does not another flow preset if already present and hasFlow option passed 1`] = `
+exports[`does not add another flow preset if already present and hasFlow option passed 1`] = `
 Object {
   "presets": Array [
     "@babel/preset-react",
@@ -48,13 +40,21 @@ Object {
 }
 `;
 
-exports[`does not another flow preset if already present in an array and hasFlow option passed 1`] = `
+exports[`does not add another flow preset if already present in an array and hasFlow option passed 1`] = `
 Object {
   "presets": Array [
     "@babel/preset-react",
     Array [
       "@babel/preset-flow",
     ],
+  ],
+}
+`;
+
+exports[`does not add flow preset if hasFlow option is not passed 1`] = `
+Object {
+  "presets": Array [
+    "@babel/preset-react",
   ],
 }
 `;

--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -22,7 +22,12 @@ Object {
   },
   "plugins": Array [
     "@babel/plugin-proposal-function-bind",
-    "@babel/plugin-proposal-class-properties",
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
   ],
   "presets": Array [
     "@babel/preset-env",
@@ -44,9 +49,7 @@ exports[`does not add another flow preset if already present in an array and has
 Object {
   "presets": Array [
     "@babel/preset-react",
-    Array [
-      "@babel/preset-flow",
-    ],
+    "@babel/preset-flow",
   ],
 }
 `;
@@ -104,7 +107,12 @@ Object {
         "useBuiltIns": true,
       },
     ],
-    "@babel/plugin-proposal-class-properties",
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
   ],
   "presets": Array [
     "@babel/preset-env",
@@ -144,7 +152,12 @@ Object {
         "useBuiltIns": true,
       },
     ],
-    "@babel/plugin-proposal-class-properties",
+    Array [
+      "@babel/plugin-proposal-class-properties",
+      Object {
+        "loose": true,
+      },
+    ],
   ],
   "presets": Array [
     "@babel/preset-env",

--- a/__tests__/upgradeConfig.test.js
+++ b/__tests__/upgradeConfig.test.js
@@ -60,7 +60,7 @@ test('does not add flow preset if hasFlow option is not passed', () => {
   expect(upgradeConfig(config, { hasFlow: false })).toMatchSnapshot();
 });
 
-test('does not another flow preset if already present and hasFlow option passed', () => {
+test('does not add another flow preset if already present and hasFlow option passed', () => {
   const config = {
     "presets": [
       "@babel/preset-react",
@@ -71,7 +71,7 @@ test('does not another flow preset if already present and hasFlow option passed'
   expect(upgradeConfig(config, { hasFlow: true })).toMatchSnapshot();
 });
 
-test('does not another flow preset if already present in an array and hasFlow option passed', () => {
+test('does not add another flow preset if already present in an array and hasFlow option passed', () => {
   const config = {
     "presets": [
       "@babel/preset-react",

--- a/__tests__/upgradeConfig.test.js
+++ b/__tests__/upgradeConfig.test.js
@@ -71,3 +71,14 @@ test('does not another flow preset if already present and hasFlow option passed'
   expect(upgradeConfig(config, { hasFlow: true })).toMatchSnapshot();
 });
 
+test('does not another flow preset if already present in an array and hasFlow option passed', () => {
+  const config = {
+    "presets": [
+      "@babel/preset-react",
+      ["@babel/preset-flow"],
+    ],
+  };
+
+  expect(upgradeConfig(config, { hasFlow: true })).toMatchSnapshot();
+});
+

--- a/src/packageData.js
+++ b/src/packageData.js
@@ -245,17 +245,9 @@ const packages = Object.assign(
 
 const latestPackages = new Set(Object.values(packages));
 
-const packagesWarnAboutEnv = new Set([
-  'babel-preset-es2015',
-  'babel-preset-es2016',
-  'babel-preset-es2017',
-  'babel-preset-latest'
-]);
-
 module.exports = {
   packages,
   presets,
   plugins,
-  latestPackages,
-  packagesWarnAboutEnv
+  latestPackages
 };

--- a/src/packageData.js
+++ b/src/packageData.js
@@ -245,9 +245,17 @@ const packages = Object.assign(
 
 const latestPackages = new Set(Object.values(packages));
 
+const packagesWarnAboutEnv = new Set([
+  'babel-preset-es2015',
+  'babel-preset-es2016',
+  'babel-preset-es2017',
+  'babel-preset-latest'
+]);
+
 module.exports = {
   packages,
   presets,
   plugins,
   latestPackages,
+  packagesWarnAboutEnv
 };

--- a/src/packageData.js
+++ b/src/packageData.js
@@ -125,7 +125,19 @@ const syntaxPlugins = {
 const proposalPlugins = {
   // not scoped, transform
   'babel-plugin-transform-async-generator-functions': '@babel/plugin-proposal-async-generator-functions',
-  'babel-plugin-transform-class-properties': '@babel/plugin-proposal-class-properties',
+  'babel-plugin-transform-class-properties': {
+    name: '@babel/plugin-proposal-class-properties',
+    optionsTransformer: function classPropertiesOptionsTransformer(options) {
+      const newOptions = Object.assign({}, options);
+
+      if (!newOptions.spec) {
+        newOptions.loose = true;
+      }
+
+      delete newOptions.spec;
+      return newOptions;
+    },
+  },
   'babel-plugin-transform-decorators': '@babel/plugin-proposal-decorators',
   'babel-plugin-transform-do-expressions': '@babel/plugin-proposal-do-expressions',
   'babel-plugin-transform-export-default': ['@babel/plugin-proposal-export-default-from', '@babel/plugin-proposal-export-namespace-from'],
@@ -245,9 +257,36 @@ const packages = Object.assign(
 
 const latestPackages = new Set(Object.values(packages));
 
+function isPackageObject(entry) {
+  return entry !== null && typeof entry === 'object' && !Array.isArray(entry);
+}
+
+function getNewPackageName(name) {
+  const entry = packages[name];
+
+  if (isPackageObject(entry)) {
+    return entry.name;
+  }
+
+  return entry;
+}
+
+function getNewPackageOptionsTransformer(name) {
+  const entry = packages[name];
+
+
+  if (isPackageObject(entry)) {
+    return entry.optionsTransformer || (options => options);
+  }
+
+  return (options => options);
+}
+
 module.exports = {
   packages,
   presets,
   plugins,
-  latestPackages
+  latestPackages,
+  getNewPackageName,
+  getNewPackageOptionsTransformer
 };

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -31,11 +31,9 @@ function transformPreset(preset) {
   const newPresetName = oldPresets[presetName];
   if (newPresetName !== undefined) {
     return Object.keys(presetOptions).length > 0 ? [newPresetName, presetOptions] : newPresetName;
-  } else {
-    return preset;
   }
 
-  return null;
+  return preset;
 }
 
 function transformPlugins(plugins) {
@@ -57,11 +55,9 @@ function transformPlugin(plugin) {
   const newPluginName = oldPlugins[pluginName];
   if (newPluginName !== undefined) {
     return Object.keys(pluginOptions).length > 0 ? [newPluginName, pluginOptions] : newPluginName;
-  } else {
-    return plugin;
   }
 
-  return null;
+  return plugin;
 }
 
 module.exports = function upgradeConfig(config, options) {

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -1,110 +1,91 @@
 const { presets: oldPresets, plugins: oldPlugins } = require('./packageData');
 
-// TODO: fix all of this
-function changePresets(config, options = {}) {
-  let presets = config.presets;
-
+function transformPresets(presets, options = {}) {
   if (!Array.isArray(presets) && typeof presets === 'string') {
-    presets = config.presets = config.presets.split(',').map((preset) => preset.trim());
+    presets = presets.split(',').map(preset => preset.trim());
   }
 
-  // check if presets are there
   if (presets) {
-    // assume it's an array
-    for (let i = 0; i < presets.length; i++) {
-      let preset = presets[i];
-      const presetsToReplace = Object.keys(oldPresets);
+    const newPresets = presets.map(transformPreset).filter(Boolean);
 
-      // check if it's a preset with options (an array)
-      if (Array.isArray(preset)) {
-        if (preset[0].indexOf('babel-preset') !== 0 && preset[0].indexOf('@babel/') !== 0) {
-          preset[0] = `babel-preset-${preset[0]}`;
-        }
-        if (presetsToReplace.includes(preset[0])) {
-          if (oldPresets[preset[0]]) {
-            preset[0] = oldPresets[preset[0]];
-          } else {
-            presets.splice(i, 1);
-            i--;
-          }
-        }
-      } else {
-        if (preset.indexOf('babel-preset') !== 0 && preset.indexOf('@babel/') !== 0) {
-          preset = `babel-preset-${preset}`;
-        }
-        if (presetsToReplace.includes(preset)) {
-          if (oldPresets[preset]) {
-            presets[i] = oldPresets[preset];
-          } else {
-            presets.splice(i, 1);
-            i--;
-          }
-        }
-      }
-    }
-
-    if (options.hasFlow && !presets.includes('@babel/preset-flow')) {
-      presets.push('@babel/preset-flow');
-    }
+    return options.hasFlow ? appendFlowIfNeeded(newPresets) : newPresets;
   }
+
+  return presets;
 }
 
-function changePlugins(config) {
-  let plugins = config.plugins;
+function appendFlowIfNeeded(presets) {
+  return presets.find(preset => preset === '@babel/preset-flow' || preset[0] === '@babel/preset-flow')
+    ? presets
+    : presets.concat(['@babel/preset-flow']);
+}
 
+function transformPreset(preset) {
+  let presetName = Array.isArray(preset) ? preset[0] : preset;
+  const presetOptions = Array.isArray(preset) ? preset[1] : {};
+
+  if (presetName.indexOf('babel-preset') !== 0 && presetName.indexOf('@babel/') !== 0) {
+    presetName = `babel-preset-${presetName}`;
+  }
+
+  const newPresetName = oldPresets[presetName];
+  if (newPresetName !== undefined) {
+    return Object.keys(presetOptions).length > 0 ? [newPresetName, presetOptions] : newPresetName;
+  } else {
+    return preset;
+  }
+
+  return null;
+}
+
+function transformPlugins(plugins) {
   if (!Array.isArray(plugins) && typeof plugins === 'string') {
-    plugins = config.plugins = config.plugins.split(',').map((plugin) => plugin.trim());
+    plugins = plugins.split(',').map(plugin => plugin.trim());
   }
 
-  // check if plugins are there
-  if (plugins) {
-    // assume it's an array
-    for (let i = 0; i < plugins.length; i++) {
-      let plugin = plugins[i];
-      const pluginsToReplace = Object.keys(oldPlugins);
+  return plugins && plugins.map(transformPlugin).filter(Boolean);
+}
 
-      // check if it's a plugin with options (an array)
-      if (Array.isArray(plugin)) {
+function transformPlugin(plugin) {
+  let pluginName = Array.isArray(plugin) ? plugin[0] : plugin;
+  const pluginOptions = Array.isArray(plugin) ? plugin[1] : {};
 
-        if (plugin[0].indexOf('babel-plugin') !== 0 && plugin[0].indexOf('@babel/') !== 0) {
-          plugin[0] = `babel-plugin-${plugin[0]}`;
-        }
-
-        if (pluginsToReplace.includes(plugin[0])) {
-          if (oldPlugins[plugin[0]]) {
-            plugin[0] = oldPlugins[plugin[0]];
-          } else {
-            plugins.splice(i, 1);
-            i--;
-          }
-        }
-      } else {
-        if (plugin.indexOf('babel-plugin') !== 0 && plugin[0].indexOf('@babel/') !== 0) {
-          plugin = `babel-plugin-${plugin}`;
-        }
-        if (pluginsToReplace.includes(plugin)) {
-          if (oldPlugins[plugin]) {
-            plugins[i] = oldPlugins[plugin];
-          } else {
-            plugins.splice(i, 1);
-            i--;
-          }
-        }
-      }
-    }
+  if (pluginName.indexOf('babel-plugin') !== 0 && pluginName.indexOf('@babel/') !== 0) {
+    pluginName = `babel-plugin-${pluginName}`;
   }
+
+  const newPluginName = oldPlugins[pluginName];
+  if (newPluginName !== undefined) {
+    return Object.keys(pluginOptions).length > 0 ? [newPluginName, pluginOptions] : newPluginName;
+  } else {
+    return plugin;
+  }
+
+  return null;
 }
 
 module.exports = function upgradeConfig(config, options) {
   config = Object.assign({}, config);
 
-  changePresets(config, options);
-  changePlugins(config);
+  if (config.presets) {
+    config.presets = transformPresets(config.presets, options);
+  }
+
+  if (config.plugins) {
+    config.plugins = transformPlugins(config.plugins);
+  }
 
   if (config.env) {
-    Object.keys(config.env).forEach((env) => {
-      changePresets(config.env[env]);
-      changePlugins(config.env[env]);
+    Object.keys(config.env).forEach(env => {
+      const envConfig = config.env[env];
+
+      if (envConfig.presets) {
+        envConfig.presets = transformPresets(envConfig.presets, options);
+      }
+
+      if (envConfig.plugins) {
+        envConfig.plugins = transformPlugins(envConfig.plugins);
+      }
     });
   }
 

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -11,7 +11,7 @@ function parseConfigCollection(collection) {
 function parseConfigItem(rawConfigItem, configItemType) {
   let name = Array.isArray(rawConfigItem) ? rawConfigItem[0] : rawConfigItem;
 
-  if (name.indexOf(`babel-${configItemType}`) !== 0 && name.indexOf('@babel/') !== 0) {
+  if (!name.startsWith(`babel-${configItemType}`) && !name.startsWith('@babel/')) {
     name = `babel-${configItemType}-${name}`;
   }
 
@@ -72,11 +72,7 @@ module.exports = function upgradeConfig(config, options = {}) {
   upgradeConfigForEnv(config, options);
 
   if (config.env) {
-    Object.keys(config.env).forEach(env => {
-      const envConfig = config.env[env];
-
-      upgradeConfigForEnv(envConfig, options);
-    });
+    Object.values(config.env).forEach(envConfig => upgradeConfigForEnv(envConfig, options));
   }
 
   return config;

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -1,5 +1,5 @@
 const semver = require('semver');
-const { packages: oldPackages, latestPackages } = require('./packageData');
+const { getNewPackageName, latestPackages } = require('./packageData');
 
 const otherPackages = {
   'babel-loader': '^8.0.0-beta.0',
@@ -9,14 +9,16 @@ const otherPackages = {
 module.exports = function upgradeDeps(dependencies, version, options = {}) {
   for (const pkg of Object.keys(dependencies)) {
     const depVersion = dependencies[pkg];
-    if (Object.keys(oldPackages).includes(pkg)) {
+
+    const newPackageName = getNewPackageName(pkg);
+    if (newPackageName !== undefined) {
       // don't update `babel-core` bridge
       if (dependencies[pkg].includes("7.0.0-bridge.0")) {
         break;
       }
 
       delete dependencies[pkg];
-      const newPackageName = oldPackages[pkg];
+
       if (newPackageName) {
         if (process.env.DEBUG) {
           console.warn(`Updating ${pkg} -> ${newPackageName}`);

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -24,7 +24,7 @@ module.exports = function upgradeDeps(dependencies, version, options = {}) {
           console.warn(`Updating ${pkg} -> ${newPackageName}`);
         }
         if (Array.isArray(newPackageName)) {
-          for (name of newPackageName) {
+          for (let name of newPackageName) {
             dependencies[name] = version;
           }
         } else {


### PR DESCRIPTION
branched from https://github.com/babel/babel-upgrade/pull/50, with some additional refactors ([diff](https://github.com/kedromelon/babel-upgrade/compare/refactor-config...kedromelon:branch-upgrade))

new approach for https://github.com/babel/babel-upgrade/issues/10 after closing https://github.com/babel/babel-upgrade/pull/47

currently only includes options transformation for class properties -- will add others here if this approach seems good to move forward with

changes: 
- adds `getNewPackageName` and `getNewPackageOptionsTransformer` to be used instead of accessing `packageData` directly:
  - if package data is an array or a string, `getNewPackageName` returns that
  - however, package data entries can now be objects instead: ```{ name: string, optionsTransformer: options -> options }```
  - if package data entry has an `optionsTransformer`, `getNewPackageOptionsTransformer` -- defaults to returning an identity function
- further abstracts parsing of config items from https://github.com/babel/babel-upgrade/pull/50 with a `ConfigItem` class
- updates snapshots for class properties 