### PR TITLE
Consider jest-cli as jest dependency

### DIFF
--- a/__tests__/__snapshots__/packageData.test.js.snap
+++ b/__tests__/__snapshots__/packageData.test.js.snap
@@ -26,6 +26,20 @@ Object {
 }
 `;
 
+exports[`jest-cli babel-core bridge 1`] = `
+Object {
+  "devDependencies": Object {
+    "@babel/core": "7.0.0-beta.44",
+    "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.44",
+    "@babel/preset-env": "7.0.0-beta.44",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-loader": "^8.0.0-beta.0",
+    "jest-cli": "22.0.0",
+  },
+  "name": "add-@babel/core-peerDep",
+}
+`;
+
 exports[`scripts 1`] = `
 Object {
   "name": "mocha-scripts-test",

--- a/__tests__/packageData.test.js
+++ b/__tests__/packageData.test.js
@@ -2,6 +2,7 @@ const { updatePackageJSON } = require('../src/');
 const upgradeDeps = require('../src/upgradeDeps');
 const babelCoreFixture = require('../fixtures/babel-core');
 const jestFixture = require('../fixtures/jest');
+const jestCliFixture = require('../fixtures/jest-cli');
 const depsFixture = require('../fixtures/deps');
 const webpackV1Fixture = require('../fixtures/webpack-v1');
 const depsFixtureEarlierBeta = require('../fixtures/deps-earlier-beta.json');
@@ -69,6 +70,10 @@ test('@babel/core peerDep', async () => {
 
 test('jest babel-core bridge', async () => {
   expect(await updatePackageJSON(jestFixture)).toMatchSnapshot();
+});
+
+test('jest-cli babel-core bridge', async () => {
+  expect(await updatePackageJSON(jestCliFixture)).toMatchSnapshot();
 });
 
 test('webpack v1 compatibility', async () => {

--- a/fixtures/jest-cli.json
+++ b/fixtures/jest-cli.json
@@ -1,0 +1,9 @@
+{
+  "name": "add-@babel/core-peerDep",
+  "devDependencies": {
+    "babel-loader": "^7.1.1",
+    "babel-plugin-transform-object-rest-spread": "^6.20.2",
+    "babel-preset-es2015": "^6.18.0",
+    "jest-cli": "22.0.0"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ npx babel-upgrade --install
 }
 ```
 
-- [x] use `"babel-core": "^7.0.0-bridge-0"` if jest is a dependency ([#14](https://github.com/babel/babel-upgrade/pull/14))
+- [x] use `"babel-core": "^7.0.0-bridge-0"` if jest or jest-cli is a dependency ([#14](https://github.com/babel/babel-upgrade/pull/14))
 
 ```diff
 "devDependencies": {

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -75,7 +75,7 @@ module.exports = function upgradeDeps(dependencies, version, options = {}) {
   // https://github.com/babel/babel-upgrade/issues/29
   // https://github.com/babel/babel-loader/issues/505
   if (
-    (dependencies['jest'] || (depsWebpack1 && dependencies['babel-loader'])) &&
+    (dependencies['jest'] || dependencies['jest-cli'] || (depsWebpack1 && dependencies['babel-loader'])) &&
     !dependencies['babel-core']
   ) {
     dependencies['babel-core'] = '^7.0.0-bridge.0';


### PR DESCRIPTION
I spent about 4 hours until I figure out what was my problem in my private project, I used `jest-cli` in my dependencies instead of `jest` (Maybe because my project is old or just an old mistake), anyway, still required the bridge solution.

### Change Log
Adding bridge version in case `jest-cli` is one of the dependencies.
Include:
- Update to the readme file.
- Adding a fixture.
- Adding a test case.