### PR TITLE
add --write flag to readme (followup for #58)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,12 +10,14 @@ Run at the root of your git repo:
 
 ```bash
 # npx lets you run babel-upgrade without installing it locally
-npx babel-upgrade
+npx babel-upgrade --write
 
 # or install globally and run
 npm install babel-upgrade -g
-babel-upgrade
+babel-upgrade --write
 ```
+
+Without the `--write` (or `-w`) flag, `babel-upgrade` will print a diff without writing any changes.
 
 Optionally use `--install` to run `yarn` or `npm` after the upgrade.
 

--- a/readme.md
+++ b/readme.md
@@ -19,10 +19,10 @@ babel-upgrade --write
 
 Without the `--write` (or `-w`) flag, `babel-upgrade` will print a diff without writing any changes.
 
-Optionally use `--install` to run `yarn` or `npm` after the upgrade.
+Optionally, add `--install` as well to run `yarn` or `npm` after writing the upgrade.
 
 ```bash
-npx babel-upgrade --install
+npx babel-upgrade --write --install
 ```
 
 > Ideas from http://new.babeljs.io/docs/en/next/v7-migration.html (or modify that file if it's missing)


### PR DESCRIPTION
as discussed in https://github.com/babel/babel-upgrade/pull/58#issuecomment-379595993, `babel-upgrade` will make no changes unless a `--write` or `-w` flag is provided after #58 is merged. this PR updates the readme to communicate this change in functionality.