### PR TITLE
Decorators legacy

### DIFF
--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -9,6 +9,45 @@ Object {
 }
 `;
 
+exports[`adds legacy option to decorators 1`] = `
+Object {
+  "plugins": Array [
+    Array [
+      "@babel/plugin-proposal-decorators",
+      Object {
+        "legacy": true,
+      },
+    ],
+    Array [
+      "@babel/plugin-syntax-decorators",
+      Object {
+        "legacy": true,
+      },
+    ],
+  ],
+  "presets": Array [
+    Array [
+      "@babel/preset-stage-0",
+      Object {
+        "decoratorsLegacy": true,
+      },
+    ],
+    Array [
+      "@babel/preset-stage-1",
+      Object {
+        "decoratorsLegacy": true,
+      },
+    ],
+    Array [
+      "@babel/preset-stage-2",
+      Object {
+        "decoratorsLegacy": true,
+      },
+    ],
+  ],
+}
+`;
+
 exports[`convert comma separated presets/plugins into an array 1`] = `
 Object {
   "env": Object {
@@ -53,7 +92,7 @@ Object {
   "plugins": Array [
     "@babel/plugin-proposal-async-generator-functions",
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-decorators",
+    "@babel/plugin-proposal-do-expressions",
   ],
 }
 `;

--- a/__tests__/upgradeConfig.test.js
+++ b/__tests__/upgradeConfig.test.js
@@ -76,8 +76,24 @@ test('handles @babel prefix in plugins', () => {
     "plugins": [
       '@babel/plugin-transform-async-generator-functions',
       '@babel/plugin-transform-class-properties',
-      '@babel/plugin-transform-decorators'
+      '@babel/plugin-transform-do-expressions'
     ],
+  };
+
+  expect(upgradeConfig(config)).toMatchSnapshot();
+});
+
+test("adds legacy option to decorators", () => {
+  const config = {
+    "plugins": [
+      "transform-decorators",
+      "@babel/plugin-syntax-decorators"
+    ],
+    "presets": [
+      "@babel/preset-stage-0",
+      "babel-preset-stage-1",
+      "stage-2"
+    ]
   };
 
   expect(upgradeConfig(config)).toMatchSnapshot();

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -1,4 +1,5 @@
 const { presets: oldPresets, plugins: oldPlugins } = require('./packageData');
+const upgradeOptions = require('./upgradeOptions');
 
 function changeName(originalName, kind) {
   const oldNames = kind === 'plugin' ? oldPlugins : oldPresets;
@@ -43,7 +44,9 @@ function changePresets(config, options = {}) {
         i--;
       } else {
         if (isArray) preset[0] = name;
-        else presets[i] = name;
+        else preset = name;
+
+        presets[i] = upgradeOptions(preset);
       }
     }
 
@@ -75,7 +78,9 @@ function changePlugins(config) {
         i--;
       } else {
         if (isArray) plugin[0] = name;
-        else plugins[i] = name;
+        else plugin = name;
+
+        plugins[i] = upgradeOptions(plugin);
       }
     }
   }

--- a/src/upgradeOptions.js
+++ b/src/upgradeOptions.js
@@ -1,0 +1,18 @@
+const define = defaults => opts => Object.assign(opts, defaults);
+
+const updaters = {
+  __proto__: null,
+  "@babel/plugin-proposal-decorators": define({ legacy: true }),
+  "@babel/plugin-syntax-decorators": define({ legacy: true }),
+  "@babel/preset-stage-0": define({ decoratorsLegacy: true }),
+  "@babel/preset-stage-1": define({ decoratorsLegacy: true }),
+  "@babel/preset-stage-2": define({ decoratorsLegacy: true }),
+};
+
+module.exports = function updateOptions(entry) {
+  const result = Array.isArray(entry) ? entry : [entry];
+  const updater = updaters[result[0]];
+  if (!updater) return entry;
+  result[1] = updater(result[1] || {});
+  return result;
+};


### PR DESCRIPTION
Depends on babel/babel#7734

The first commit isn't strictly necessary, but it was the easiest way I found to make the `upgradeOptions` work both for plugins whose name changes and whose name remains the same.