### PR TITLE
stub console.log and console.warn in index.test.js

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -7,6 +7,19 @@ jest.mock('write', () => jest.fn().mockResolvedValue({}));
 const writeJsonFile = require('write-json-file');
 const writeFile = require('write');
 
+let logSpy;
+let warnSpy;
+
+beforeAll(() => {
+  logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterAll(() => {
+  logSpy.mockReset();
+  warnSpy.mockReset();
+});
+
 test('does not write when --write is not passed', async () => {
 
   await writePackageJSON({ write: false });


### PR DESCRIPTION
noticed there was a bunch of noise in the tests after adding `index.test.js` in https://github.com/babel/babel-upgrade/pull/58

i added stubs for `console.log` and `console.warn` in that file to silence them

perhaps in a future PR we could also assert that the correct output is logged?