### PR TITLE
Prevent adding duplicate plugins

### DIFF
--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -192,6 +192,93 @@ Object {
 }
 `;
 
+exports[`prevent dupe plugins 1`] = `
+Object {
+  "env": Object {
+    "development": Object {
+      "plugins": Array [
+        "react-hot-loader/babel",
+      ],
+    },
+    "production": Object {
+      "plugins": Array [
+        "transform-react-remove-prop-types",
+      ],
+    },
+    "test": Object {
+      "plugins": Array [
+        "@babel/plugin-transform-runtime",
+        Array [
+          "@babel/plugin-proposal-decorators",
+          Object {
+            "legacy": true,
+          },
+        ],
+        "@babel/plugin-transform-react-display-name",
+        "@babel/plugin-proposal-class-properties",
+        Array [
+          "import",
+          Object {
+            "libraryName": "antd",
+            "style": "css",
+          },
+        ],
+      ],
+      "presets": Array [
+        Array [
+          "@babel/preset-env",
+          Object {
+            "loose": true,
+            "modules": false,
+            "targets": Object {
+              "browsers": Array [
+                "> 0.25%",
+              ],
+            },
+            "useBuiltIns": "usage",
+          },
+        ],
+        "@babel/preset-react",
+      ],
+    },
+  },
+  "plugins": Array [
+    Array [
+      "@babel/plugin-proposal-decorators",
+      Object {
+        "legacy": true,
+      },
+    ],
+    "@babel/plugin-transform-react-display-name",
+    "@babel/plugin-proposal-class-properties",
+    Array [
+      "import",
+      Object {
+        "libraryName": "antd",
+        "style": "css",
+      },
+    ],
+  ],
+  "presets": Array [
+    Array [
+      "@babel/preset-env",
+      Object {
+        "loose": true,
+        "modules": false,
+        "targets": Object {
+          "browsers": Array [
+            "> 0.25%",
+          ],
+        },
+        "useBuiltIns": "usage",
+      },
+    ],
+    "@babel/preset-react",
+    "@babel/preset-flow",
+  ],
+}
+`;
+
 exports[`rename community packages 1`] = `
 Object {
   "env": Object {
@@ -209,33 +296,6 @@ Object {
 
 exports[`replaces stage presets 1`] = `
 Object {
-  "plugins": Array [
-    "@babel/plugin-syntax-dynamic-import",
-    "@babel/plugin-syntax-import-meta",
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-json-strings",
-    Array [
-      "@babel/plugin-proposal-decorators",
-      Object {
-        "legacy": true,
-      },
-    ],
-    "@babel/plugin-proposal-function-sent",
-    "@babel/plugin-proposal-export-namespace-from",
-    "@babel/plugin-proposal-numeric-separator",
-    "@babel/plugin-proposal-throw-expressions",
-    "@babel/plugin-proposal-export-default-from",
-    "@babel/plugin-proposal-logical-assignment-operators",
-    "@babel/plugin-proposal-optional-chaining",
-    Array [
-      "@babel/plugin-proposal-pipeline-operator",
-      Object {
-        "proposal": "minimal",
-      },
-    ],
-    "@babel/plugin-proposal-nullish-coalescing-operator",
-    "@babel/plugin-proposal-do-expressions",
-  ],
   "presets": Array [],
 }
 `;

--- a/__tests__/__snapshots__/upgradeConfig.test.js.snap
+++ b/__tests__/__snapshots__/upgradeConfig.test.js.snap
@@ -258,6 +258,24 @@ Object {
         "style": "css",
       },
     ],
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-json-strings",
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-logical-assignment-operators",
+    "@babel/plugin-proposal-optional-chaining",
+    Array [
+      "@babel/plugin-proposal-pipeline-operator",
+      Object {
+        "proposal": "minimal",
+      },
+    ],
+    "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-do-expressions",
   ],
   "presets": Array [
     Array [
@@ -296,6 +314,33 @@ Object {
 
 exports[`replaces stage presets 1`] = `
 Object {
+  "plugins": Array [
+    "@babel/plugin-syntax-dynamic-import",
+    "@babel/plugin-syntax-import-meta",
+    "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-json-strings",
+    Array [
+      "@babel/plugin-proposal-decorators",
+      Object {
+        "legacy": true,
+      },
+    ],
+    "@babel/plugin-proposal-function-sent",
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-numeric-separator",
+    "@babel/plugin-proposal-throw-expressions",
+    "@babel/plugin-proposal-export-default-from",
+    "@babel/plugin-proposal-logical-assignment-operators",
+    "@babel/plugin-proposal-optional-chaining",
+    Array [
+      "@babel/plugin-proposal-pipeline-operator",
+      Object {
+        "proposal": "minimal",
+      },
+    ],
+    "@babel/plugin-proposal-nullish-coalescing-operator",
+    "@babel/plugin-proposal-do-expressions",
+  ],
   "presets": Array [],
 }
 `;

--- a/__tests__/upgradeConfig.test.js
+++ b/__tests__/upgradeConfig.test.js
@@ -2,6 +2,7 @@ const path = require('path');
 const upgradeConfig = require('../src/upgradeConfig');
 const babelrcFixture = require('../fixtures/babelrc');
 const optionParsingFixture = require('../fixtures/option-parsing');
+const dupesProspectFixture = require('../fixtures/dupes-prospect');
 const { readBabelRC } = require('../src');
 const JSON5_PATH = path.resolve(__dirname, '../fixtures/babelrc.json5');
 
@@ -113,4 +114,8 @@ test("replaces stage presets", () => {
   };
 
   expect(upgradeConfig(config)).toMatchSnapshot();
+});
+
+test("prevent dupe plugins", () => {
+  expect(upgradeConfig(dupesProspectFixture)).toMatchSnapshot();
 });

--- a/fixtures/dupes-prospect.json
+++ b/fixtures/dupes-prospect.json
@@ -1,0 +1,57 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "useBuiltIns": "usage",
+        "targets": {
+          "browsers": ["> 0.25%"]
+        },
+        "modules": false,
+        "loose": true
+      }
+    ],
+    "stage-1",
+    "react",
+    "flow"
+  ],
+
+  "plugins": [
+    "transform-decorators-legacy",
+    "transform-react-display-name",
+    "transform-class-properties",
+    ["import", { "libraryName": "antd", "style": "css" }]
+  ],
+
+  "env": {
+    "production": {
+      "plugins": ["transform-react-remove-prop-types"]
+    },
+    "development": {
+      "plugins": ["react-hot-loader/babel"]
+    },
+    "test": {
+      "presets": [
+        [
+          "env",
+          {
+            "useBuiltIns": "usage",
+            "targets": {
+              "browsers": ["> 0.25%"]
+            },
+            "modules": false,
+            "loose": true
+          }
+        ],
+        "react"
+      ],
+      "plugins": [
+        "transform-runtime",
+        "transform-decorators-legacy",
+        "transform-react-display-name",
+        "transform-class-properties",
+        ["import", { "libraryName": "antd", "style": "css" }]
+      ]
+    }
+  }
+}

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -61,6 +61,7 @@ function changePresets(config, options = {}) {
     }
 
     if (newPlugins.length > 0) {
+      config.plugins = (config.plugins || []).concat(...newPlugins);
     }
   }
 }

--- a/src/upgradeConfig.js
+++ b/src/upgradeConfig.js
@@ -61,13 +61,13 @@ function changePresets(config, options = {}) {
     }
 
     if (newPlugins.length > 0) {
-      config.plugins = (config.plugins || []).concat(...newPlugins);
     }
   }
 }
 
 function changePlugins(config) {
   let plugins = config.plugins;
+  const uniquePlugins = new Set();
 
   if (!Array.isArray(plugins) && typeof plugins === 'string') {
     plugins = config.plugins = config.plugins.split(',').map((plugin) => plugin.trim());
@@ -83,10 +83,11 @@ function changePlugins(config) {
       const isArray = Array.isArray(plugin);
 
       const name = changeName(isArray ? plugin[0] : plugin, 'plugin');
-      if (name === null) {
+      if (name === null || uniquePlugins.has(name)) {
         plugins.splice(i, 1);
         i--;
       } else {
+        uniquePlugins.add(name);
         if (isArray) plugin[0] = name;
         else plugin = name;
 


### PR DESCRIPTION
### Summary
Prevent adding duplicate plugins

### Bug description
After upgrading an old config I got this error:

```sh
Module build failed: Error: Duplicate plugin/preset detected.
```

#### Old config
```json
{
  "presets": [
    ["env", {
      "useBuiltIns": "usage",
      "targets": {
        "browsers": ["> 0.25%"]
      },
      "modules": false,
      "loose": true
    }],
    "stage-1",
    "react",
    "flow"
  ],

  "plugins": [
    "transform-decorators-legacy",
    "transform-react-display-name",
    "transform-class-properties",
    ["import", { "libraryName": "antd", "style": "css" }]
  ],

  "env": {
    "production": {
      "plugins": ["transform-react-remove-prop-types"]
    },
    "development": {
      "plugins": [
        "react-hot-loader/babel"
      ]
    },
    "test": {
      "presets": [
        ["env", {
          "useBuiltIns": "usage",
          "targets": {
            "browsers": ["> 0.25%"]
          },
          "modules": false,
          "loose": true
        }],
        "react"
      ],
      "plugins": [
        "transform-runtime",
        "transform-decorators-legacy",
        "transform-react-display-name",
        "transform-class-properties",
        ["import", { "libraryName": "antd", "style": "css" }]
      ]
    }
  }
}

```

#### After upgrade

```json
{
  "presets": [
    [
      "@babel/preset-env",
      {
        "useBuiltIns": "usage",
        "targets": {
          "browsers": [
            "> 0.25%"
          ]
        },
        "modules": false,
        "loose": true
      }
    ],
    "@babel/preset-react",
    "@babel/preset-flow"
  ],
  "plugins": [
    [
      "@babel/plugin-proposal-decorators",
      {
        "legacy": true
      }
    ],
    "@babel/plugin-transform-react-display-name",
    "@babel/plugin-proposal-class-properties",
    [
      "import",
      {
        "libraryName": "antd",
        "style": "css"
      }
    ],
    "@babel/plugin-syntax-dynamic-import",
    "@babel/plugin-syntax-import-meta",
    "@babel/plugin-proposal-class-properties",
    "@babel/plugin-proposal-json-strings",
    [
      "@babel/plugin-proposal-decorators",
      {
        "legacy": true
      }
    ],
    "@babel/plugin-proposal-function-sent",
    "@babel/plugin-proposal-export-namespace-from",
    "@babel/plugin-proposal-numeric-separator",
    "@babel/plugin-proposal-throw-expressions",
    "@babel/plugin-proposal-export-default-from",
    "@babel/plugin-proposal-logical-assignment-operators",
    "@babel/plugin-proposal-optional-chaining",
    [
      "@babel/plugin-proposal-pipeline-operator",
      {
        "proposal": "minimal"
      }
    ],
    "@babel/plugin-proposal-nullish-coalescing-operator",
    "@babel/plugin-proposal-do-expressions"
  ],
  "env": {
    "production": {
      "plugins": [
        "transform-react-remove-prop-types"
      ]
    },
    "development": {
      "plugins": [
        "react-hot-loader/babel"
      ]
    },
    "test": {
      "presets": [
        [
          "@babel/preset-env",
          {
            "useBuiltIns": "usage",
            "targets": {
              "browsers": [
                "> 0.25%"
              ]
            },
            "modules": false,
            "loose": true
          }
        ],
        "@babel/preset-react"
      ],
      "plugins": [
        "@babel/plugin-transform-runtime",
        [
          "@babel/plugin-proposal-decorators",
          {
            "legacy": true
          }
        ],
        "@babel/plugin-transform-react-display-name",
        "@babel/plugin-proposal-class-properties",
        [
          "import",
          {
            "libraryName": "antd",
            "style": "css"
          }
        ]
      ]
    }
  }
}

```

#### Duplicates

```

[
  "@babel/plugin-proposal-decorators",
  {
    "legacy": true
  }
],
"@babel/plugin-proposal-class-properties",

```

### Solution
This code uses a `Set` to keep track of existing plugin names and prevents adding dupes. Duplicates are discarded.