### PR TITLE
Avoid broken link when following link on terminal

### DIFF
--- a/bin/babel-upgrade
+++ b/bin/babel-upgrade
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-console.log("🙌  Thanks for trying out https://github.com/babel/babel-upgrade!");
+console.log("🙌  Thanks for trying out https://github.com/babel/babel-upgrade !");
 console.log("");
 
 require('@babel/polyfill');


### PR DESCRIPTION
clinking on terminal lead to 'https://github.com/babel/babel-upgrade!', which was 404 because of the bang.

Adding a space to fix that 😉 

Your tool saved my day!! 😃 