### PR TITLE
#108 Prevent babel-jest downgrade

### DIFF
--- a/__tests__/__snapshots__/packageData.test.js.snap
+++ b/__tests__/__snapshots__/packageData.test.js.snap
@@ -25,6 +25,16 @@ Object {
 }
 `;
 
+exports[`doesn't downgrade jest >= 24  1`] = `
+Object {
+  "devDependencies": Object {
+    "babel-jest": "^24.0.0",
+    "jest": "^24.0.0",
+  },
+  "name": "add-@babel/core-peerDep",
+}
+`;
+
 exports[`jest babel-core bridge 1`] = `
 Object {
   "devDependencies": Object {

--- a/__tests__/packageData.test.js
+++ b/__tests__/packageData.test.js
@@ -4,6 +4,7 @@ const babelCoreFixture = require('../fixtures/babel-core');
 const avaFixture = require('../fixtures/ava');
 const jestFixture = require('../fixtures/jest');
 const jestCliFixture = require('../fixtures/jest-cli');
+const jest24Fixture = require('../fixtures/jest-v24');
 const depsFixture = require('../fixtures/deps');
 const webpackV1Fixture = require('../fixtures/webpack-v1');
 const depsFixtureEarlierBeta = require('../fixtures/deps-earlier-beta.json');
@@ -51,6 +52,10 @@ test('jest babel-core bridge', async () => {
 
 test('jest-cli babel-core bridge', async () => {
   expect(await updatePackageJSON(jestCliFixture)).toMatchSnapshot();
+});
+
+test("doesn't downgrade jest >= 24 ", async () => {
+  expect(await updatePackageJSON(jest24Fixture)).toMatchSnapshot();
 });
 
 test('webpack v1 compatibility', async () => {

--- a/fixtures/jest-v24.json
+++ b/fixtures/jest-v24.json
@@ -1,0 +1,7 @@
+{
+  "name": "add-@babel/core-peerDep",
+  "devDependencies": {
+    "jest": "^24.0.0",
+    "babel-jest": "^24.0.0"
+  }
+}

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -84,14 +84,19 @@ module.exports = function upgradeDeps(dependencies, version, options = {}) {
   // and babel-loader.
   // https://github.com/babel/babel-upgrade/issues/29
   // https://github.com/babel/babel-loader/issues/505
+  const JEST_MAJOR_VERSION_COMPATIBLE_WITH_BABEL_7 = 24;
+  const legacyJest = ['jest', 'jest-cli']
+    .map(pkgName => semver.coerce(dependencies[pkgName]))
+    .some(pkgVersion => pkgVersion && (pkgVersion.major < JEST_MAJOR_VERSION_COMPATIBLE_WITH_BABEL_7));
+
   if (
-    (dependencies['jest'] || dependencies['jest-cli'] || (depsWebpack1 && dependencies['babel-loader'])) &&
+    (legacyJest || (depsWebpack1 && dependencies['babel-loader'])) &&
     !dependencies['babel-core']
   ) {
     dependencies['babel-core'] = '^7.0.0-bridge.0';
   }
 
-  if (dependencies['jest'] || dependencies['jest-cli']) {
+  if (legacyJest) {
     dependencies['babel-jest'] = '^23.4.2';
   }
 

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -80,7 +80,7 @@ module.exports = function upgradeDeps(dependencies, version, options = {}) {
     dependencies['babel-loader'] = '7.1.1';
   }
 
-  // babel-bridge is needed for Jest, or for when a project is using Webpack v1
+  // babel-bridge is needed for Jest < 24, or for when a project is using Webpack v1
   // and babel-loader.
   // https://github.com/babel/babel-upgrade/issues/29
   // https://github.com/babel/babel-loader/issues/505

--- a/src/upgradeDeps.js
+++ b/src/upgradeDeps.js
@@ -84,10 +84,10 @@ module.exports = function upgradeDeps(dependencies, version, options = {}) {
   // and babel-loader.
   // https://github.com/babel/babel-upgrade/issues/29
   // https://github.com/babel/babel-loader/issues/505
-  const JEST_MAJOR_VERSION_COMPATIBLE_WITH_BABEL_7 = 24;
+  const JEST_BABEL_7_ONLY_VERSION = 24;
   const legacyJest = ['jest', 'jest-cli']
     .map(pkgName => semver.coerce(dependencies[pkgName]))
-    .some(pkgVersion => pkgVersion && (pkgVersion.major < JEST_MAJOR_VERSION_COMPATIBLE_WITH_BABEL_7));
+    .some(pkgVersion => pkgVersion && (pkgVersion.major < JEST_BABEL_7_ONLY_VERSION));
 
   if (
     (legacyJest || (depsWebpack1 && dependencies['babel-loader'])) &&


### PR DESCRIPTION
Fixes #108 
---
In v24 Jest [upgraded to Babel 7 and dropped support for Babel 6](https://github.com/facebook/jest/blob/master/CHANGELOG.md#fixes-10), so we don't need to do anything with it. 